### PR TITLE
Implement secrets storage using Secrets Service API via D-Bus

### DIFF
--- a/Astra/Astra.AtProtocol.Common/Interfaces/ICredentialProvider.cs
+++ b/Astra/Astra.AtProtocol.Common/Interfaces/ICredentialProvider.cs
@@ -4,7 +4,7 @@ namespace Astra.AtProtocol.Common.Interfaces;
 
 public interface ICredentialProvider
 {
-    public AtCredential? GetCredential();
+    public Task<AtCredential?> GetCredential();
     
-    public bool SetCredential(AtCredential credential);
+    public Task<bool> SetCredential(AtCredential credential);
 }

--- a/Astra/Astra.AtProtocol.Common/Models/Credentials/AtCredential.cs
+++ b/Astra/Astra.AtProtocol.Common/Models/Credentials/AtCredential.cs
@@ -1,7 +1,14 @@
+using System.Text.Json;
+
 namespace Astra.AtProtocol.Common.Models.Credentials;
 
 public class AtCredential(string username, string password)
 {
-    public string Username { get; set; } = username;
-    public string Password { get; set; } = password;
+    public string Username { get; } = username;
+    public string Password { get; } = password;
+
+    public string ToJson()
+    {
+        return JsonSerializer.Serialize(this);
+    }
 }

--- a/Astra/Astra.AtProtocol.Common/Providers/Credentials/LocalMemoryCredentialProvider.cs
+++ b/Astra/Astra.AtProtocol.Common/Providers/Credentials/LocalMemoryCredentialProvider.cs
@@ -8,15 +8,15 @@ public class LocalMemoryCredentialProvider : ICredentialProvider
 {
     private AtCredential? _credential;
     
-    public AtCredential? GetCredential()
+    public Task<AtCredential?> GetCredential()
     {
-        return _credential;
+        return Task.FromResult(_credential);
     }
 
-    public bool SetCredential(AtCredential credential)
+    public Task<bool> SetCredential(AtCredential credential)
     {
         _credential = credential;
 
-        return true;
+        return Task.FromResult(true);
     }
 }

--- a/Astra/Astra.Gtk/Astra.Gtk.csproj
+++ b/Astra/Astra.Gtk/Astra.Gtk.csproj
@@ -19,6 +19,7 @@
     <ItemGroup>
       <ProjectReference Include="..\Astra.AtProtocol.Client\Astra.AtProtocol.Client.csproj" />
       <ProjectReference Include="..\Astra.AtProtocol.Common\Astra.AtProtocol.Common.csproj" />
+      <ProjectReference Include="..\Astra.Provider.Credentials.DBusSecretService\Astra.Provider.Credentials.DBusSecretService.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Astra/Astra.Gtk/Program.cs
+++ b/Astra/Astra.Gtk/Program.cs
@@ -3,8 +3,8 @@ using System.Reflection;
 using Astra.AtProtocol.Client.Interfaces;
 using Astra.AtProtocol.Client.Services;
 using Astra.AtProtocol.Common.Interfaces;
-using Astra.AtProtocol.Common.Providers.Credentials;
 using Astra.Gtk;
+using Astra.Provider.Credentials.DBusSecretService;
 using FishyFlip;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -31,7 +31,7 @@ var serviceProvider = new ServiceCollection()
     .AddSingleton(atProtocol)
     .AddSingleton<ISessionService, SessionService>()
     .AddSingleton<IUserFeedService, UserFeedService>()
-    .AddSingleton<ICredentialProvider, LocalMemoryCredentialProvider>((x) => new LocalMemoryCredentialProvider())
+    .AddSingleton<ICredentialProvider, SecretServiceProvider>()
     .AddSingleton<ApplicationEntry>()
     .BuildServiceProvider();
     

--- a/Astra/Astra.Gtk/Views/FeedList.cs
+++ b/Astra/Astra.Gtk/Views/FeedList.cs
@@ -66,17 +66,6 @@ public class Feed : Box
 
     private async Task InitializeAt(Builder builder)
     {
-        var credential = _credentialProvider.GetCredential();
-        
-        ArgumentNullException.ThrowIfNull(credential);
-
-        // TODO: Move the login logic out of the feed widget. It should be handled earlier.
-        await _sessionService.LoginWithPassword(
-            identifier: credential.Username,
-            password: credential.Password,
-            CancellationToken.None
-        );
-
         await FetchPosts();
 
         var scrollAdjustment = _feedScroll?.Vadjustment;

--- a/Astra/Astra.Gtk/Views/MainWindow.cs
+++ b/Astra/Astra.Gtk/Views/MainWindow.cs
@@ -10,11 +10,7 @@ public class MainWindow : Adw.ApplicationWindow
 {
     [Connect("home_page_container")]
     private readonly Box? _homeStackContainer = null;
-    
-    private readonly ISessionService _sessionService;
-    private readonly IUserFeedService _userFeedService;
-    private readonly ICredentialProvider _credentialProvider;
-    private readonly ILoggerFactory _loggerFactory;
+
     private readonly ILogger<MainWindow> _logger;
     private readonly Builder _builder;
 
@@ -28,19 +24,16 @@ public class MainWindow : Adw.ApplicationWindow
     {
         builder.Connect(this);
 
-        _sessionService = sessionService;
-        _userFeedService = userFeedService;
-        _credentialProvider = credentialProvider;
         _builder = builder;
-        _loggerFactory = loggerFactory;
         _logger = loggerFactory.CreateLogger<MainWindow>();
         
-        // Set the panel
-        _homeStackContainer?.Append(new Feed(
-            _sessionService,
-            _userFeedService,
-            _credentialProvider,
-            _loggerFactory));
+        var feed = new Feed(
+            sessionService,
+            userFeedService,
+            credentialProvider,
+            loggerFactory);
+        
+        _homeStackContainer?.Append(feed);
     }
 
     public MainWindow(

--- a/Astra/Astra.Gtk/Views/OnboardWindow.cs
+++ b/Astra/Astra.Gtk/Views/OnboardWindow.cs
@@ -42,7 +42,7 @@ public class OnboardWindow : Adw.ApplicationWindow
         _sessionService = sessionService;
         _credentialProvider = credentialProvider;
         _logger = loggerFactory.CreateLogger<OnboardWindow>();
-
+        
         ArgumentNullException.ThrowIfNull(_signInButton);
 
         _signInButton.OnClicked += SignInButtonOnClicked;
@@ -94,7 +94,7 @@ public class OnboardWindow : Adw.ApplicationWindow
             return;
         }
 
-        var saved = _credentialProvider.SetCredential(new AtCredential(username, password));
+        var saved = await _credentialProvider.SetCredential(new AtCredential(username, password));
 
         if (saved is false)
         {

--- a/Astra/Astra.Provider.Credentials.DBusSecretService/Astra.Provider.Credentials.DBusSecretService.csproj
+++ b/Astra/Astra.Provider.Credentials.DBusSecretService/Astra.Provider.Credentials.DBusSecretService.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Astra.AtProtocol.Common\Astra.AtProtocol.Common.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <Reference Include="Microsoft.Extensions.Logging.Abstractions">
+        <HintPath>..\..\..\..\.nuget\packages\microsoft.extensions.logging.abstractions\9.0.1\lib\net8.0\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
+      </Reference>
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Ace4896.DBus.Services.Secrets" Version="1.3.0" />
+    </ItemGroup>
+
+</Project>

--- a/Astra/Astra.Provider.Credentials.DBusSecretService/SecretServiceProvider.cs
+++ b/Astra/Astra.Provider.Credentials.DBusSecretService/SecretServiceProvider.cs
@@ -1,0 +1,121 @@
+using System.Text;
+using System.Text.Json;
+using Astra.AtProtocol.Common.Interfaces;
+using Astra.AtProtocol.Common.Models.Credentials;
+using DBus.Services.Secrets;
+using Microsoft.Extensions.Logging;
+
+namespace Astra.Provider.Credentials.DBusSecretService;
+
+public class SecretServiceProvider(ILogger<ICredentialProvider> logger) : ICredentialProvider
+{
+    private const string SecretLabel = "Astra Credential";
+    
+    private readonly Dictionary<string, string> _attributes = new()
+    {
+        { "name", "app.astra.gtk.credential" }
+    };
+    
+    private SecretService? _secretService;
+    
+    public async Task<AtCredential?> GetCredential()
+    {
+        logger.LogDebug("{MethodName}: Getting Credential...", nameof(GetCredential));
+        
+        var collection = await GetCollection();
+
+        if (collection == null)
+        {
+            logger.LogError("Secret Service Provider failed to retrieve credential " +
+                             "because the collection was not available for use.");
+            return null;
+        }
+        
+        var items = await collection.SearchItemsAsync(_attributes);
+        var item = items.SingleOrDefault();
+
+        if (item == null)
+        {
+            logger.LogDebug("Secret Service Provider failed to retrieve credential. " +
+                             "Has it been created?");
+            
+            return null;
+        }
+        
+        logger.LogDebug(
+            "Secret Service Provider retrieved credential which was created at {CreatedAt}. Attempting to parse into valid object...",
+            await item.GetCreatedAsync());
+        
+        var secret = await item.GetSecretAsync();
+        var secretString = Encoding.UTF8.GetString(secret);
+        var credential = JsonSerializer.Deserialize<AtCredential>(secretString);
+
+        return credential;
+    }
+
+    public async Task<bool> SetCredential(AtCredential credential)
+    {
+        logger.LogDebug("{MethodName}: Setting Credential...", nameof(SetCredential));
+        
+        var collection = await GetCollection();
+
+        if (collection == null)
+        {
+            logger.LogError("Secret Service Provider failed to create credential " +
+                             "because the collection was not available for use.");
+            
+            return false;
+        }
+        
+        var secretBytes = Encoding.UTF8.GetBytes(credential.ToJson());
+        const string contentType = "application/json; charset=utf8";
+
+        var created = await collection.CreateItemAsync(
+            label: SecretLabel,
+            lookupAttributes: _attributes,
+            secret: secretBytes,
+            contentType: contentType,
+            replace: true);
+
+        if (created is null)
+        {
+            logger.LogError("Secret Service Provider failed to create credential due to unknown error.");
+        }
+
+        return created is not null;
+    }
+
+    private async Task<Collection?> GetCollection()
+    {
+        var secretService = await GetSecretService();
+        
+        var defaultCollection = await secretService.GetDefaultCollectionAsync();
+
+        if (defaultCollection == null)
+        {
+            logger.LogError("Could not retrieve default collection, exiting");
+            return null;
+        }
+        
+        var defaultCollectionProperties = await defaultCollection.GetAllPropertiesAsync();
+
+        if (defaultCollectionProperties.Locked)
+        {
+            await defaultCollection.UnlockAsync();
+        }
+
+        return defaultCollection;
+    }
+
+    private async Task<SecretService> GetSecretService()
+    {
+        if (_secretService != null)
+        {
+            return _secretService;
+        }
+        
+        _secretService = await SecretService.ConnectAsync(EncryptionType.Dh);
+        
+        return _secretService;
+    }
+}

--- a/Astra/Astra.sln
+++ b/Astra/Astra.sln
@@ -11,6 +11,14 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Docs", "Docs", "{7FFBD950-D
 		..\README.md = ..\README.md
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Providers", "Providers", "{BEAC1940-D8D5-4626-8AA4-9F4344F87EAA}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Credentials", "Credentials", "{3AE8664F-DD86-40DA-8711-76DD61DE3904}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Astra.Provider.Credentials.DBusSecretService", "Astra.Provider.Credentials.DBusSecretService\Astra.Provider.Credentials.DBusSecretService.csproj", "{1A533F3C-769B-4105-A7AB-079B8E3418E1}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "External", "External", "{9A21DB31-ED5F-4936-907F-4BEB8FE4A6E7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -29,7 +37,13 @@ Global
 		{CE843CA6-05CE-4789-8DAF-643FA4800905}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CE843CA6-05CE-4789-8DAF-643FA4800905}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CE843CA6-05CE-4789-8DAF-643FA4800905}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1A533F3C-769B-4105-A7AB-079B8E3418E1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1A533F3C-769B-4105-A7AB-079B8E3418E1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1A533F3C-769B-4105-A7AB-079B8E3418E1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1A533F3C-769B-4105-A7AB-079B8E3418E1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
+		{3AE8664F-DD86-40DA-8711-76DD61DE3904} = {BEAC1940-D8D5-4626-8AA4-9F4344F87EAA}
+		{1A533F3C-769B-4105-A7AB-079B8E3418E1} = {3AE8664F-DD86-40DA-8711-76DD61DE3904}
 	EndGlobalSection
 EndGlobal

--- a/README.md
+++ b/README.md
@@ -13,10 +13,9 @@
 
 ## 🛣️ Roadmap
 
-- [ ] Login
-    - [ ] Credential storage
-    - [ ] Change provider
-- [ ] Timeline
+- Login
+    - [X] Credential storage
+- Timeline
     - [X] Avatar
     - [X] Text
     - [ ] Image
@@ -38,6 +37,10 @@
     - [ ] Notifications
     - [ ] Messages
     - [ ] Translations
+- Other
+  - [ ] Change provider
+
+See open issues for further detail.
 
 ## 🛠️ Building from source
 
@@ -72,6 +75,8 @@ This project is licensed under the `MIT` license. See the `LICENSE.md` file for 
 ## 😇 Acknowledgements
 
 Astra uses the following libraries:
+
 - [FishyFlip](https://github.com/drasticactions/FishyFlip)
 - [Gir.Core](https://github.com/gircore/)
 - [Blueprint](https://jwestman.pages.gitlab.gnome.org/blueprint-compiler/)
+- [DBus.Services.Secrets](https://github.com/Ace4896/DBus.Services.Secrets)


### PR DESCRIPTION
Use `org.freedesktop.Secret.Service`  API via D-Bus to store, and retrieve credentials.

https://specifications.freedesktop.org/secret-service-spec/0.2/org.freedesktop.Secret.Service.html

The actual handling of D-Bus is provided by the package `Ace4896.DBus.Services.Secrets`.